### PR TITLE
Don't add column hash table if doesn't required

### DIFF
--- a/export.py
+++ b/export.py
@@ -23,7 +23,8 @@ def export_to_gcs(args):
         # Create a struct containing all filtered columns
         struct_col = F.struct(*[F.col(c) for c in filtered_cols])
         # Convert the struct to a JSON string and compute hash
-        df = df.withColumn(args.computed_hash_column, F.md5(F.to_json(struct_col)))
+        if len(args.computed_hash_column) != 0:
+            df = df.withColumn(args.computed_hash_column, F.md5(F.to_json(struct_col)))
     if args.export_format == "csv":
         df.coalesce(1).write.format(args.export_format).option("compression", "gzip").option("header", "true").mode("overwrite").save(f"gs://{args.bucket}//{args.prefix}/")
     else:


### PR DESCRIPTION
Export from Databricks will have extra column of {"": hash}. This would interfere with the logic in importer. 

In importer, if we have empty key with value set, that value will be used for any field which the customer haven't defined. 