### PR TITLE
[DEV-72] chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Check formatting
         run: uvx ruff format --check .
@@ -27,10 +27,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Run tests
         run: uv run --group dev pytest -v


### PR DESCRIPTION
## Summary
Pin all GitHub Actions workflow steps to immutable full commit SHAs instead of mutable tags or branches.

## Why
Mutable tags can be moved after the fact, making it possible for a supply-chain attack to inject malicious code into CI. Pinning to a commit SHA ensures the exact version of an action is used, and the original tag is preserved as an inline comment for readability.

## Verification
Review the diff — all `uses:` lines with third-party actions should now reference a 40-character commit SHA with the original tag as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: https://linear.app/mixpanel/issue/DEV-72/pin-all-github-actions-to-commit-shas