### PR TITLE
Limit none safety in validate_row_count

### DIFF
--- a/export.py
+++ b/export.py
@@ -114,6 +114,7 @@ def _get_cdc_table_query(
         return f"SELECT 'INSERT' as _mp_change_type, * FROM {table_ref} TIMESTAMP AS OF '{end_dt.isoformat()}'"
     # Add 1ms to exclude entries already processed (Databricks timestamps are at millisecond precision)
     cutoff_dt = ms_to_datetime(time_cutoff_ms + 1)
+    print(f"cdc_table_changes start timestamp: ${cutoff_dt.isoformat()}, end timestamp: ${end_dt.isoformat()}")
     return f"""
     SELECT CASE
         WHEN _change_type = 'update_postimage' THEN 'INSERT'

--- a/export.py
+++ b/export.py
@@ -114,7 +114,9 @@ def _get_cdc_table_query(
         return f"SELECT 'INSERT' as _mp_change_type, * FROM {table_ref} TIMESTAMP AS OF '{end_dt.isoformat()}'"
     # Add 1ms to exclude entries already processed (Databricks timestamps are at millisecond precision)
     cutoff_dt = ms_to_datetime(time_cutoff_ms + 1)
-    print(f"cdc_table_changes start timestamp: ${cutoff_dt.isoformat()}, end timestamp: ${end_dt.isoformat()}")
+    print(
+        f"cdc_table_changes start timestamp: ${cutoff_dt.isoformat()}, end timestamp: ${end_dt.isoformat()}"
+    )
     return f"""
     SELECT CASE
         WHEN _change_type = 'update_postimage' THEN 'INSERT'

--- a/export.py
+++ b/export.py
@@ -31,7 +31,7 @@ def generate_filter(non_nullable_columns: str | None) -> str:
 def validate_row_count(
     spark: SparkSession, catalog: str, schema: str, table: str, limit: int
 ) -> None:
-    if limit is None or limit <= 0:
+    if limit <= 0:
         return
 
     try:
@@ -276,6 +276,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--validate_row_count",
         type=int,
+        default=0,
         help="Fail if row count exceeds this limit (0=no limit)",
     )
     parser.add_argument(

--- a/export.py
+++ b/export.py
@@ -31,7 +31,7 @@ def generate_filter(non_nullable_columns: str | None) -> str:
 def validate_row_count(
     spark: SparkSession, catalog: str, schema: str, table: str, limit: int
 ) -> None:
-    if limit == None or limit <= 0:
+    if limit is None or limit <= 0:
         return
 
     try:

--- a/export.py
+++ b/export.py
@@ -31,7 +31,7 @@ def generate_filter(non_nullable_columns: str | None) -> str:
 def validate_row_count(
     spark: SparkSession, catalog: str, schema: str, table: str, limit: int
 ) -> None:
-    if limit <= 0:
+    if limit == None or limit <= 0:
         return
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,4 +9,4 @@ sys.modules["pyspark.sql"] = MagicMock()
 sys.modules["pyspark.sql.functions"] = MagicMock()
 
 mock_dbutils = MagicMock()
-builtins.dbutils = mock_dbutils  # type: ignore[attr-defined]
+setattr(builtins, "dbutils", mock_dbutils)


### PR DESCRIPTION
Customer somehow got an error where the `limit` was `None`. Not sure how that can happen from reading the code but just adding this check to at least resolve it for now.

Slack thread context: https://mixpanel.slack.com/archives/C04E6U2NN1X/p1779257101301259