### PR TITLE
[DF-692] Remove unnecessary/buggy line in export.py

### DIFF
--- a/export.py
+++ b/export.py
@@ -205,7 +205,6 @@ def export_to_gcs_with_query(
     ignore_columns = args.computed_hash_ignore_columns.split()
     if len(ignore_columns) > 0:
         filtered_cols = [c for c in df.columns if c not in ignore_columns]
-        filtered_cols = [c for c in df.columns if c not in args.computed_hash_ignore_columns]
         filtered_cols.sort()
         # Create a struct containing all filtered columns
         struct_col = F.struct(*[F.col(c) for c in filtered_cols])


### PR DESCRIPTION
Addressing bug/issue from here: https://mixpanel.slack.com/archives/C04E6U2NN1X/p1786655312033139

This line was unneeded. The line before it literally does what it intends to do correctly by checking strict equality of each column name in the arg list of ignored columns.

How this fixes the issue: For mirror, each "row" that is processed by WHC has the actual row data, but also a `_mp_change_type` of `INSERT` or `DELETE` that tells us whether we need to insert a new event or delete an existing one. In order to match existing events to delete for `DELETE`s, we compute a hash on the row contents. We ignore 4 columns that contain mirror-specific metadata, those being `"_change_type _commit_version _mp_change_type _commit_timestamp"`. 

What was happening above was that we were accidently checking the column name against the whole string, not the list-split version of the string. This means any column name that is a substring of that long string, for example a column called `time` would match and be ignored in the has computation, even though it should be included.