### PR TITLE
[DF-736] Improving databricks full group sync

### DIFF
--- a/export.py
+++ b/export.py
@@ -175,7 +175,16 @@ def build_query(spark: SparkSession, args: argparse.Namespace) -> tuple[str, dic
         if not args.group_id_column or not args.scd_time_column:
             raise ValueError("scd-latest sync requires --group_id_column and --scd_time_column")
         filter_condition = generate_filter(args.non_nullable_columns)
-        where_clause = f" WHERE {filter_condition}" if filter_condition else ""
+        where_parts = [filter_condition] if filter_condition else []
+        if args.time_cutoff_ms > 0:
+            cutoff_dt = args.time_cutoff_ms + 1
+            end_dt = _get_latest_timestamp(spark)
+            where_parts.append(
+                f"{args.group_id_column} IN ("
+                f" SELECT DISTINCT {args.group_id_column} "
+                f" FROM table_changes('{table_ref}', '{cutoff_dt.isoformat()}', '{end_dt.isoformat()}'))"
+            )
+        where_clause = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
         return (
             f"""SELECT *
 FROM (


### PR DESCRIPTION
Context: https://mixpanel.slack.com/archives/C07B4PN5PAM/p1786653629499499

For full group syncs (group syncs that have historical table selected), the WHC process is in two stages. Stage 1 is a normal sync (warehousetogcs then gcsimport). This is for loading in all the historical data for scd. Stage 2 is a sync again but this time using the `groups_full_sync_handler` code. This is for loading the most up to date version of each group's information.

What's happening in stage 2 is that we always do a full sync backfill. This code is improving this by making it so that the full group sync now only happens for groups that were also changed in stage 1. This is done by editing the python script so that it looks for group ids that were changed in this iteration of mirror syncs (stage 1).

Go code updates: https://github.com/mixpanel/analytics/pull/100910


# Test / Rollout plan
Check that full group syncs in [this project](https://mixpanel.com/project/3936146/app/settings/project/warehousedata) after the 
