### PR TITLE
Converts SCD cutoff timestamp to datetime before formatting

### DIFF
--- a/export.py
+++ b/export.py
@@ -177,7 +177,7 @@ def build_query(spark: SparkSession, args: argparse.Namespace) -> tuple[str, dic
         filter_condition = generate_filter(args.non_nullable_columns)
         where_parts = [filter_condition] if filter_condition else []
         if args.time_cutoff_ms > 0:
-            cutoff_dt = args.time_cutoff_ms + 1
+            cutoff_dt = ms_to_datetime(args.time_cutoff_ms + 1)
             end_dt = _get_latest_timestamp(spark)
             where_parts.append(
                 f"{args.group_id_column} IN ("


### PR DESCRIPTION
**Description**

We observed ingestion failures following the recent changes introduced in [commit c0330cea](https://github.com/mixpanel/pyspark-unload-to-gcs/commit/c0330cead29876842609f8dad23c7cf4a3759f5f).

The SCD incremental-sync logic calculated cutoff_dt by adding 1 millisecond directly to time_cutoff_ms. This produced an integer, but the code subsequently called .isoformat() on it, resulting in:
**AttributeError: 'int' object has no attribute 'isoformat'**

This PR fixes the issue by converting the cutoff timestamp from epoch milliseconds to a timezone-aware datetime before formatting it for the Delta table_changes query.

**Change**
cutoff_dt = ms_to_datetime(args.time_cutoff_ms + 1)